### PR TITLE
Use data.resource rather than userRequest

### DIFF
--- a/lib/bower-plugin.js
+++ b/lib/bower-plugin.js
@@ -102,7 +102,7 @@ BowerWebpackPlugin.prototype.apply = function (compiler) {
   compiler.plugin("normal-module-factory", function (nmf) {
     nmf.plugin("after-resolve", function (data, callback) {
 
-      if (!manifestMainFiles.hasOwnProperty(data.userRequest)) {
+      if (!manifestMainFiles.hasOwnProperty(data.resource)) {
         return callback(null, data);
       }
 
@@ -112,11 +112,11 @@ BowerWebpackPlugin.prototype.apply = function (compiler) {
         return dirname.substring(indexOfLastSeparator + 1);
       }
 
-      var bowerComponentName = componentName(data.userRequest),
+      var bowerComponentName = componentName(data.resource),
         bowerLoaderPath = path.join(__dirname, "bower-loader"),
-        bowerLoaderParams = JSON.stringify({include: manifestMainFiles[data.userRequest]});
+        bowerLoaderParams = JSON.stringify({include: manifestMainFiles[data.resource]});
 
-      data.loaders = [bowerLoaderPath + "?" + bowerLoaderParams];
+      data.loaders = data.loaders.concat(bowerLoaderPath + "?" + bowerLoaderParams);
       data.request = bowerComponentName + " (bower component)";
       data.userRequest = bowerComponentName + " (bower component)";
 


### PR DESCRIPTION
When I tried to use the plugin with angular-webpack-plugin, which replaces all occurrences of the variable angular to require ('exports? window.angular! angular'), when you build, I got an error:

ERROR in ./~/exports-loader?window.angular!./assets/vendor/angular/bower.json
Module parse failed: /node_modules/exports-loader/index.js?window.angular!/vendor/angular/bower.json Line 2: Unexpected token :
You may need an appropriate loader to handle this file type.
| {
|   "name": "angular",
|   "version": "1.3.8",
|   "main": "./angular.js",
