### PR TITLE
Revert a commit with data.loaders (fix #10)

### DIFF
--- a/lib/bower-plugin.js
+++ b/lib/bower-plugin.js
@@ -116,7 +116,7 @@ BowerWebpackPlugin.prototype.apply = function (compiler) {
         bowerLoaderPath = path.join(__dirname, "bower-loader"),
         bowerLoaderParams = JSON.stringify({include: manifestMainFiles[data.resource]});
 
-      data.loaders = data.loaders.concat(bowerLoaderPath + "?" + bowerLoaderParams);
+      data.loaders = [bowerLoaderPath + "?" + bowerLoaderParams];
       data.request = bowerComponentName + " (bower component)";
       data.userRequest = bowerComponentName + " (bower component)";
 


### PR DESCRIPTION
We should not support custom loaders for manifest main files