### PR TITLE
Syntax error in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ plugins: [
   new BowerWebpackPlugin({
     modulesDirectories: ["bower_components"],
     manifestFiles:      "bower.json",
-    includes:           /.*/
+    includes:           /.*/,
     excludes:           [],
     searchResolveModulesDirectories: true
   })


### PR DESCRIPTION
Fixed a small syntax error in the defaults you show in the Readme. Thanks a lot for the plugin!