### PR TITLE
fix syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ plugins: [
   new BowerWebpackPlugin({
     modulesDirectories: ["bower_components"],
     manifestFiles:      "bower.json",
-    includes:           /.*/
+    includes:           /.*/,
     excludes:           [],
     searchResolveModulesDirectories: true
   })


### PR DESCRIPTION
Missing comma in the example config :3
