### PR TITLE
Packages can now be excluded with excludePackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The plugin takes options object as its single argument.
 
 * `excludes` {`RegExp[]` or `RegExp`} - the plugin will match files contained in a manifest, and will exclude all files, which match any of the expressions.
 
+* `excludePackages` {`string[]` or `string`} - the plugin will match packages names contained in a manifest, and will exclude all packages with the same name.
+
 * `searchResolveModulesDirectories` {`boolean`} - if `false`, the plugin will not search [`resolve.modulesDirectories`](http://webpack.github.io/docs/configuration.html#resolve-modulesdirectories) for bower components.
 
 Using the plugin, without specifying the configuration is equivalent to following:
@@ -50,6 +52,7 @@ plugins: [
     manifestFiles:      "bower.json",
     includes:           /.*/,
     excludes:           [],
+    excludePackages:    [],
     searchResolveModulesDirectories: true
   })
 ]

--- a/lib/bower-plugin.js
+++ b/lib/bower-plugin.js
@@ -54,6 +54,7 @@ function BowerWebpackPlugin(options) {
   this.manifestFiles = opt.manifestFiles ? [].concat(opt.manifestFiles) : ["bower.json"];
   this.includes = opt.includes ? [].concat(opt.includes) : [/.*/];
   this.excludes = opt.excludes ? [].concat(opt.excludes) : [];
+  this.excludePackages = opt.excludePackages ? [].concat(opt.excludePackages) : [];
   this.searchResolveModulesDirectories = opt.searchResolveModulesDirectories === false ? false : true;
 }
 
@@ -65,6 +66,7 @@ BowerWebpackPlugin.prototype.apply = function (compiler) {
     manifestFiles = this.manifestFiles,
     includes = this.includes,
     excludes = this.excludes,
+    excludePackages = this.excludePackages,
     manifestMainFiles = {};
 
     compiler.resolvers.normal.plugin('module', function (request, finalCallback) {
@@ -75,7 +77,7 @@ BowerWebpackPlugin.prototype.apply = function (compiler) {
 
     // the plugin does not support modules with slashes - no nesting here...
     // e.g. require('some-module/whatever'); will not be resolved
-    if (request.request.indexOf('/') >= 0) {
+    if (request.request.indexOf('/') >= 0 || excludePackages.indexOf(request.request) >= 0) {
       return finalCallback();
     }
 

--- a/test/package-exclusions.js
+++ b/test/package-exclusions.js
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Lukasz Piepiora <lpiepiora@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+var testUtils = require('./test-utils');
+
+var BowerWebpackPlugin = require("../");
+
+testUtils.describe("resolving of modules, with exclusion of unwanted packages", function () {
+  var config = testUtils.config;
+  var testBowerPlugin = testUtils.testBowerPlugin;
+
+  it("should exclude unwanted packages based on the package name (string test)", function (done) {
+    var expectations = {
+      js:  [],
+      css: []
+    };
+
+    var cfg = config("module-single-array");
+    cfg.plugins = [
+      new BowerWebpackPlugin({excludePackage: "module-single-array"})
+    ];
+
+    testBowerPlugin(cfg, expectations, done);
+  });
+
+  it("should exclude unwanted files based on the package name (array test)", function (done) {
+    var expectations = {
+      js:  [],
+      css: []
+    };
+
+    var cfg = config("module-single-array");
+    cfg.plugins = [
+      new BowerWebpackPlugin({excludePackage: ["module-single-array", "module-multiple-js"]})
+    ];
+
+    testBowerPlugin(cfg, expectations, done);
+  });
+
+});


### PR DESCRIPTION
In my case I needed to exclude angular from bower and use the npm version instead because of the export support (`import angular from "angular";`). I need to keep angular referenced in bower.json to other angular packages like angular-translate, ... Also I have an old grunt build system that need to exist during the migration to webpack.

What I propose is a new parameter excludePackages to list all packages that we want to exclude from bower.

Also, there is an issue that could be solve by this PR: #30 
